### PR TITLE
fix affiliation fields for proper namespaces

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -104,7 +104,6 @@ export default function (JXT) {
         element: 'affiliation',
         fields: {
             node: Utils.attribute('node'),
-            jid: Utils.jidAttribute('jid'),
             type: Utils.attribute('affiliation')
         }
     });
@@ -114,8 +113,7 @@ export default function (JXT) {
         namespace: NS.PUBSUB,
         element: 'affiliations',
         fields: {
-            node: Utils.attribute('node'),
-            jid: Utils.jidAttribute('jid')
+            node: Utils.attribute('node')
         }
     });
 

--- a/src/pubsubOwner.js
+++ b/src/pubsubOwner.js
@@ -67,7 +67,7 @@ export default function (JXT) {
         namespace: NS.PUBSUB_OWNER,
         element: 'affiliation',
         fields: {
-            node: Utils.attribute('node'),
+            jid: Utils.jidAttribute('jid'),
             type: Utils.attribute('affiliation')
         }
     });


### PR DESCRIPTION
In the pubsub#owner namespace affiliation only needs jid and affiliation. In pubsub namespace needs node and affiliation.

Affiliations never needs jid
