### PR TITLE
Fix XEP-0276 decloak element namespace reference.

### DIFF
--- a/src/presence.js
+++ b/src/presence.js
@@ -51,7 +51,7 @@ internals.definePresence = function (JXT, name, namespace) {
                 }
             },
             idleSince: Utils.dateSubAttribute(NS.IDLE_1, 'idle', 'since'),
-            decloak: Utils.subAttribute(NS.DECLOAK_0, 'decloak', 'reason'),
+            decloak: Utils.subAttribute(NS.DECLOAKING_0, 'decloak', 'reason'),
             avatarId: {
                 get: function () {
 


### PR DESCRIPTION
There is a typo in specifying the `decloak` element namespace (`DECLOAK_0` vs `DECLOAKING_0`) that causes the element to be transmitted with no namespace and not recognized by the recipient.

The correct name is specified in xmpp-constants:

https://github.com/otalk/xmpp-constants/blob/master/lib/namespaces.js#L243
