### PR TITLE
Adding support for use of createNode with a type

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -22,7 +22,10 @@ export default function (JXT) {
                 },
                 set: function (value) {
 
-                    if (value === true || !value) {
+                    if (value && value.node && value.type) {
+                        Utils.setSubAttribute(this.xml, NS.PUBSUB, 'create', 'node', value.node);
+                        Utils.setSubAttribute(this.xml, NS.PUBSUB, 'create', 'type', value.type);
+                    } else if (value === true || !value) {
                         Utils.setBoolSub(this.xml, NS.PUBSUB, 'create', value);
                     } else {
                         Utils.setSubAttribute(this.xml, NS.PUBSUB, 'create', 'node', value);


### PR DESCRIPTION
patch to make it work with http://mongooseim.readthedocs.io/en/2.1.0/user-guide/Push-notifications/#setting-up-an-xmpp-pubsub-node  XEP-0357

```
client.createNode('pubsub.domain.com', {node:'123', type: 'push'}) 
```