### PR TITLE
Add `default` Tag to `pubsubOwner` NS

### DIFF
--- a/src/pubsubOwner.js
+++ b/src/pubsubOwner.js
@@ -90,10 +90,16 @@ export default function (JXT) {
         }
     });
 
+    let Default = JXT.define({
+        name: 'default',
+        namespace: NS.PUBSUB_OWNER,
+        element: 'default'
+    });
 
     JXT.extend(PubsubOwner, Configure);
     JXT.extend(PubsubOwner, Subscriptions);
     JXT.extend(PubsubOwner, Affiliations);
+    JXT.extend(PubSub, Default);
 
     JXT.extend(Subscriptions, Subscription, 'list');
     JXT.extend(Affiliations, Affiliation, 'list');


### PR DESCRIPTION
The `default`-tag in the `pubsub#ower` namespace (As specified in [xep-0060](https://xmpp.org/extensions/xep-0060.html)), is missing. It is used to request default node configuration options.