### PR TITLE
Update pubsubEvents.js

### DIFF
--- a/src/pubsubEvents.js
+++ b/src/pubsubEvents.js
@@ -113,7 +113,8 @@ export default function (JXT) {
         fields: {
             id: Utils.attribute('id'),
             node: Utils.attribute('node'),
-            publisher: Utils.jidAttribute('publisher')
+            publisher: Utils.jidAttribute('publisher'),
+            entry: Utils.subText(_xmppConstants.Namespace.PUBSUB_EVENT,'entry')
         }
     });
 


### PR DESCRIPTION
Added pubsub item 'entry' content tag as defined at https://xmpp.org/extensions/xep-0060.html. Without it the item actual content will not transfered in stanza.io pubsub plug-in.